### PR TITLE
Fix arrow key focus handling

### DIFF
--- a/assets/js/details-menu-bar.mjs
+++ b/assets/js/details-menu-bar.mjs
@@ -255,7 +255,9 @@ export class DetailsMenuBarElement extends HTMLElement {
         setTimeout( () => {
             if (this.open) {
                 currentlyOpen = this;
-                this.querySelector("summary").focus();
+                if (!this.querySelector(":focus")) {
+                    this.querySelector("summary").focus();
+                }
             }
         });
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -203,6 +203,13 @@ struct NewPostForm {
 #[post("/-submit", data = "<post>")]
 fn create(user: User, conn: MoreInterestingConn, post: Form<NewPostForm>) -> Result<impl Responder<'static>, Status> {
     let NewPostForm { title, url } = &*post;
+    let url = url.as_ref().map(|u| {
+        if !u.contains(":") && !u.starts_with("//") {
+            format!("https://{}", u)
+        } else {
+            u.to_owned()
+        }
+    });
     match conn.create_post(&NewPost {
         title: &title,
         url: url.as_ref().map(|s| &s[..]),


### PR DESCRIPTION
The rules here are fairly complicated, but in general:

Opening a menu should focus the summary, unless there's another thing focusing in there.

Pressing the up or down arrow should focus the first or last menu item, not the summary.