### PR TITLE
Fix weird bugs

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -59,8 +59,16 @@ h1 {
 
 figcaption,
 figure,
-main {
+header,
+main,
+footer {
     display: block;
+    overflow: hidden;
+    padding: 8px;
+}
+
+footer {
+    padding-top: 0;
 }
 
 figure {
@@ -348,12 +356,10 @@ article, aside {
     border: solid 1px #0c0c0d;
     background: #f9f9fa;
     margin: 24px 0;
-    padding: 8px 8px;
 }
 
 .article-header {
     margin-top: -24px;
-    margin-bottom: 4px;
     display: block;
 }
 
@@ -368,6 +374,7 @@ article, aside {
     border-bottom: solid 1px #0f1126;
     box-shadow: 0 1px 0 #0c0c0d;
     color: #fff;
+    padding: 0;
 }
 .top-header-link {
     color: #fff;
@@ -378,8 +385,6 @@ article, aside {
 
 .module-aside {
     float: right;
-    position: relative;
-    left: 4px;
 }
 
 details-dialog, .details-menu-inner {

--- a/src/main.rs
+++ b/src/main.rs
@@ -542,7 +542,7 @@ struct GetEditComment {
 #[get("/edit-comment?<comment..>")]
 fn get_edit_comment(conn: MoreInterestingConn, user: User, flash: Option<FlashMessage>, comment: Form<GetEditComment>, config: State<SiteConfig>) -> Option<impl Responder<'static>> {
     let comment = conn.get_comment_by_id(comment.comment).ok()?;
-    if !user.trust_level < 3 && comment.created_by != user.id {
+    if user.trust_level < 3 && comment.created_by != user.id {
         return None;
     }
     Some(Template::render("edit-comment", &TemplateContext {

--- a/src/models.rs
+++ b/src/models.rs
@@ -8,7 +8,7 @@ use serde::Serialize;
 use crate::base32::Base32;
 use std::cmp::max;
 use ordered_float::OrderedFloat;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use crate::prettify::{self, prettify_title};
 
 #[derive(Queryable, Serialize)]
@@ -302,7 +302,7 @@ impl MoreInterestingConn {
             })
             .get_result::<Post>(&self.0);
         if let Ok(ref post) = result {
-            for tag in title_html_and_stuff.hash_tags.iter().chain(excerpt_html_and_stuff.iter().flat_map(|e| e.hash_tags.iter())) {
+            for tag in title_html_and_stuff.hash_tags.iter().chain(excerpt_html_and_stuff.iter().flat_map(|e| e.hash_tags.iter())).map(|s| &s[..]).collect::<HashSet<&str>>() {
                 if let Ok(tag_info) = self.get_tag_by_name(&tag) {
                     diesel::insert_into(post_tagging::table)
                         .values(CreatePostTagging {
@@ -334,7 +334,7 @@ impl MoreInterestingConn {
             .execute(&self.0)?;
         diesel::delete(post_tagging.filter(post_id.eq(post_id_value)))
             .execute(&self.0)?;
-        for tag in title_html_and_stuff.hash_tags.iter().chain(excerpt_html_and_stuff.iter().flat_map(|e| e.hash_tags.iter())) {
+        for tag in title_html_and_stuff.hash_tags.iter().chain(excerpt_html_and_stuff.iter().flat_map(|e| e.hash_tags.iter())).map(|s| &s[..]).collect::<HashSet<&str>>() {
             if let Ok(tag_info) = self.get_tag_by_name(&tag) {
                 diesel::insert_into(post_tagging)
                     .values(CreatePostTagging {

--- a/templates/comments.hbs
+++ b/templates/comments.hbs
@@ -5,6 +5,7 @@
             {{#if posts.0.excerpt_html}}
                 <main>{{{posts.0.excerpt_html}}}</main>
             {{/if}}
+            <footer>
             submitted by <a href="@{{posts.0.submitted_by_username}}">{{posts.0.submitted_by_username}}</a>
             on {{date posts.0.created_at}}
             {{#if starred_by}}
@@ -27,10 +28,11 @@
                     <img width=12 height=12 src=assets/flag.svg alt="Add flag">
                 </button>
             </form>
+            </footer>
         </article>
         {{#each comments}}
             <aside>
-                {{{this.html}}}
+                <main>{{{this.html}}}</main>
                 <footer>
                     posted by <a href="@{{this.created_by_username}}">{{this.created_by_username}}</a>
                     {{date this.created_at}}

--- a/templates/comments.hbs
+++ b/templates/comments.hbs
@@ -7,7 +7,7 @@
             {{/if}}
             <footer>
             submitted by <a href="@{{posts.0.submitted_by_username}}">{{posts.0.submitted_by_username}}</a>
-            on {{date posts.0.created_at}}
+            {{date posts.0.created_at}}
             {{#if starred_by}}
                 starred by
                 {{#each starred_by}}

--- a/templates/index.hbs
+++ b/templates/index.hbs
@@ -6,6 +6,7 @@
         {{#if this.excerpt_html}}
             <main>{{{this.excerpt_html}}}</main>
         {{/if}}
+        <footer>
         submitted by <a href="@{{this.submitted_by_username}}">{{this.submitted_by_username}}</a>
         {{date this.created_at}} and got
         <a href={{this.uuid}}>{{this.comment_count}} comments</a>
@@ -22,6 +23,7 @@
                 <img width=12 height=12 src=assets/flag.svg alt="Add flag">
             </button>
         </form>
+        </footer>
     </article>
 {{/each}}
 </ajax-form>

--- a/templates/layout.hbs
+++ b/templates/layout.hbs
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta name=viewport content="width=device-width">
-<link rel=stylesheet href="assets/style.css?3">
+<link rel=stylesheet href="assets/style.css?4">
 <style>{{{config.custom_css}}}</style>
 <title>{{title}}</title>
 <header class=top-header>


### PR DESCRIPTION
Based on my testing, and on feedback from Lobsters.

* The permission bug prevents editing a post of another users.
* The tagging bug caused a 500 error whenever the user mentions the hashtag more than once (such as mentioning it once in the body and once in the title).
* The CSS bug allowed text to overflow outside of its box. That's a potential security vulnerability if the user abuses things like Zalgo text, but in any case it's a bug caused by things like long URLs.