### PR TITLE
Fix unicode in titles

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -362,6 +362,8 @@ article, aside {
 
 .article-header {
     margin-top: -24px;
+    margin-bottom: -8px;
+    padding: 0 12px;
     display: block;
 }
 
@@ -369,6 +371,9 @@ article, aside {
     background: #f9f9fa;
     padding: 8px 8px;
     outline-offset: -8px;
+    display: inline-block;
+    overflow: hidden;
+    margin: 0 -4px;
 }
 
 .top-header {

--- a/src/prettify.rs
+++ b/src/prettify.rs
@@ -7,7 +7,7 @@ const URL_PROTOCOLS: &[&str] = &["http:", "https:", "ftp:", "gopher:", "mailto:"
 lazy_static!{
     static ref CLEANER: ammonia::Builder<'static> = {
         let mut b = ammonia::Builder::default();
-        b.add_allowed_classes("a", ["inner-link"][..].iter().cloned());
+        b.add_allowed_classes("a", ["inner-link", "article-header-inner"][..].iter().cloned());
         b
     };
 }
@@ -206,7 +206,7 @@ pub fn prettify_body<D: Data>(text: &str, data: &mut D) -> Output {
 /// Prettify a title line: similar to `prettify_body`, but without paragraph breaks
 pub fn prettify_title<D: Data>(mut text: &str, url: &str, data: &mut D) -> Output {
     let mut ret_val = Output::with_capacity(text.len());
-    ret_val.push_str("<a href=\"");
+    ret_val.push_str("<a class=article-header-inner href=\"");
     ret_val.push_str(url);
     ret_val.push_str("\">");
     while let Some(c) = text.as_bytes().get(0) {
@@ -276,7 +276,7 @@ fn maybe_write_username<D: Data>(username_without_at: &str, data: &mut D, out: &
     if data.check_username(username_without_at) {
         out.usernames.push(username_without_at.to_owned());
         if embedded.is_some() {
-            out.push_str("</a><a class=inner-link href=\"@");
+            out.push_str("</a><a class=\"inner-link article-header-inner\" href=\"@");
         } else {
             out.push_str("<a href=\"@");
         }
@@ -284,7 +284,7 @@ fn maybe_write_username<D: Data>(username_without_at: &str, data: &mut D, out: &
         out.push_str("\">@");
         out.push_str(&html);
         if let Some(embedded) = embedded {
-            out.push_str("</a><a href=\"");
+            out.push_str("</a><a class=article-header-inner href=\"");
             out.push_str(embedded);
             out.push_str("\">");
         } else {
@@ -309,7 +309,7 @@ fn maybe_write_number_sign<D: Data>(number_without_sign: &str, data: &mut D, out
         NumberSign::Tag(tag) => {
             out.hash_tags.push(tag.to_owned());
             if embedded.is_some() {
-                out.push_str("</a><a class=inner-link href=\"/?tag=");
+                out.push_str("</a><a class=\"inner-link article-header-inner\" href=\"/?tag=");
             } else {
                 out.push_str("<a href=\"/?tag=");
             }
@@ -317,7 +317,7 @@ fn maybe_write_number_sign<D: Data>(number_without_sign: &str, data: &mut D, out
             out.push_str("\">#");
             out.push_str(&html);
             if let Some(embedded) = embedded {
-                out.push_str("</a><a href=\"");
+                out.push_str("</a><a class=article-header-inner href=\"");
                 out.push_str(embedded);
                 out.push_str("\">");
             } else {
@@ -327,7 +327,7 @@ fn maybe_write_number_sign<D: Data>(number_without_sign: &str, data: &mut D, out
         NumberSign::Comment(id) => {
             out.comment_refs.push(id);
             if embedded.is_some() {
-                out.push_str("</a><a class=inner-link href=\"#");
+                out.push_str("</a><a class=\"inner-link article-header-inner\" href=\"#");
             } else {
                 out.push_str("<a href=\"#");
             }
@@ -335,7 +335,7 @@ fn maybe_write_number_sign<D: Data>(number_without_sign: &str, data: &mut D, out
             out.push_str("\">#");
             out.push_str(&html);
             if let Some(embedded) = embedded {
-                out.push_str("</a><a href=\"");
+                out.push_str("</a><a class=article-header-inner href=\"");
                 out.push_str(embedded);
                 out.push_str("\">");
             } else {
@@ -542,7 +542,7 @@ mod test {
             }
         }
 
-        let html = "<a href=\"url\">this is a #test for </a><a class=inner-link href=\"/?tag=words\">#words</a><a href=\"url\"> here</a>";
+        let html = "<a class=article-header-inner href=\"url\">this is a #test for </a><a class=\"inner-link article-header-inner\" href=\"/?tag=words\">#words</a><a class=article-header-inner href=\"url\"> here</a>";
 
         assert_eq!(prettify_title(title, "url", &mut MyData).string, CLEANER.clean(html).to_string());
     }
@@ -603,7 +603,7 @@ mod test {
     #[test]
     fn test_unicode_title() {
         let comment = "finger— inciting the two officers to fire";
-        let html = "<a href=\"url\">finger— inciting the two officers to fire</a>";
+        let html = "<a class=article-header-inner href=\"url\">finger— inciting the two officers to fire</a>";
         struct MyData;
         impl Data for MyData {
             fn check_comment_ref(&mut self, id: i32) -> bool {

--- a/src/prettify.rs
+++ b/src/prettify.rs
@@ -256,7 +256,7 @@ pub fn prettify_title<D: Data>(mut text: &str, url: &str, data: &mut D) -> Outpu
                     }
                 }
                 while text.as_bytes().get(i).cloned().map(is_normal).unwrap_or(false) {
-                    if starts_with_url_protocol(&text[i..]) || text[i..].starts_with("www.") {
+                    if text.is_char_boundary(i) && (starts_with_url_protocol(&text[i..]) || text[i..].starts_with("www.")) {
                         break;
                     }
                     i += 1;
@@ -599,6 +599,24 @@ mod test {
             }
         }
         assert_eq!(prettify_body(comment, &mut MyData).string, CLEANER.clean(html).to_string());
+    }
+    #[test]
+    fn test_unicode_title() {
+        let comment = "finger— inciting the two officers to fire";
+        let html = "<a href=\"url\">finger— inciting the two officers to fire</a>";
+        struct MyData;
+        impl Data for MyData {
+            fn check_comment_ref(&mut self, id: i32) -> bool {
+                id == 12345
+            }
+            fn check_hash_tag(&mut self, tag: &str) -> bool {
+                tag == "words"
+            }
+            fn check_username(&mut self, username: &str) -> bool {
+                username == "mentioning"
+            }
+        }
+        assert_eq!(prettify_title(comment, "url", &mut MyData).string, CLEANER.clean(html).to_string());
     }
     #[test]
     fn test_multiple_brackets_pre() {

--- a/templates/comments.hbs
+++ b/templates/comments.hbs
@@ -1,7 +1,7 @@
 {{#*inline "page"}}
     <ajax-form>
         <article>
-            <header class=article-header><span class="article-header-inner">{{{posts.0.title_html}}}</span></header>
+            <header class=article-header>{{{posts.0.title_html}}}</header>
             {{#if posts.0.excerpt_html}}
                 <main>{{{posts.0.excerpt_html}}}</main>
             {{/if}}

--- a/templates/index.hbs
+++ b/templates/index.hbs
@@ -2,7 +2,7 @@
 <ajax-form>
 {{#each posts}}
     <article>
-        <header class=article-header><span class="article-header-inner">{{{this.title_html}}}</span></header>
+        <header class=article-header>{{{this.title_html}}}</header>
         {{#if this.excerpt_html}}
             <main>{{{this.excerpt_html}}}</main>
         {{/if}}

--- a/templates/layout.hbs
+++ b/templates/layout.hbs
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta name=viewport content="width=device-width">
-<link rel=stylesheet href="assets/style.css?5">
+<link rel=stylesheet href="assets/style.css?6">
 <style>{{{config.custom_css}}}</style>
 <title>{{title}}</title>
 <header class=top-header>


### PR DESCRIPTION
Fixes parsing of the title area (offsetting stupidity) and get it to also be `overflow:hidden`