### PR TITLE
Add a way to store comments that aren't connected to users

### DIFF
--- a/migrations/2019-04-29-234942_legacy_comments/down.sql
+++ b/migrations/2019-04-29-234942_legacy_comments/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE legacy_comments;

--- a/migrations/2019-04-29-234942_legacy_comments/up.sql
+++ b/migrations/2019-04-29-234942_legacy_comments/up.sql
@@ -1,0 +1,13 @@
+CREATE TABLE legacy_comments (
+    id SERIAL PRIMARY KEY,
+    post_id INTEGER NOT NULL REFERENCES posts(id),
+    author VARCHAR NOT NULL,
+    text VARCHAR NOT NULL,
+    html VARCHAR NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_legacy_comments ON legacy_comments(post_id);
+
+SELECT diesel_manage_updated_at('legacy_comments');

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ use rocket_contrib::serve::StaticFiles;
 use rocket_contrib::templates::{Template, handlebars};
 use serde::Serialize;
 use std::borrow::Cow;
-use crate::models::{PostInfo, NewStar, NewUser, CommentInfo, NewPost, NewComment, NewStarComment, NewTag, Tag, Comment, ModerationInfo, NewFlag, NewFlagComment};
+use crate::models::{PostInfo, NewStar, NewUser, CommentInfo, NewPost, NewComment, NewStarComment, NewTag, Tag, Comment, ModerationInfo, NewFlag, NewFlagComment, LegacyComment};
 use base32::Base32;
 use url::Url;
 use std::collections::HashMap;

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,7 +80,7 @@ struct TemplateContext {
     posts: Vec<PostInfo>,
     starred_by: Vec<String>,
     comments: Vec<CommentInfo>,
-    legacy_comments: Vec<LegacyComments>,
+    legacy_comments: Vec<LegacyComment>,
     comment: Option<Comment>,
     user: User,
     parent: &'static str,
@@ -1049,7 +1049,7 @@ struct ModerateCommentForm {
     action: String,
 }
 
-#[get("/rebake/:from/:to")]
+#[get("/rebake/<from>/<to>")]
 fn rebake(conn: MoreInterestingConn, _user: Moderator, from: i32, to: i32) -> &'static str {
     for i in from ..= to {
         if let Ok(post) = conn.get_post_by_id(i) {
@@ -1065,7 +1065,7 @@ fn rebake(conn: MoreInterestingConn, _user: Moderator, from: i32, to: i32) -> &'
             let _ = conn.update_comment(i, comment.id, &comment.text);
         }
         if let Ok(legacy_comment) = conn.get_legacy_comment_by_id(i) {
-            let _ = conn.update_legacy_comment(i, comment.id, &comment.text);
+            let _ = conn.update_legacy_comment(i, legacy_comment.id, &legacy_comment.text);
         }
     }
     "done"

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,6 +80,7 @@ struct TemplateContext {
     posts: Vec<PostInfo>,
     starred_by: Vec<String>,
     comments: Vec<CommentInfo>,
+    legacy_comments: Vec<LegacyComments>,
     comment: Option<Comment>,
     user: User,
     parent: &'static str,
@@ -525,6 +526,10 @@ fn get_comments(conn: MoreInterestingConn, user: Option<User>, uuid: Base32, con
             warn!("Failed to get comments: {:?}", e);
             Vec::new()
         });
+        let legacy_comments = conn.get_legacy_comments_from_post(post_info.id, user.id).unwrap_or_else(|e| {
+            warn!("Failed to get comments: {:?}", e);
+            Vec::new()
+        });
         let post_id = post_info.id;
         let title = Cow::Owned(post_info.title.clone());
         Ok(Template::render("comments", &TemplateContext {
@@ -533,7 +538,7 @@ fn get_comments(conn: MoreInterestingConn, user: Option<User>, uuid: Base32, con
             alert: flash.map(|f| f.msg().to_owned()),
             starred_by: conn.get_post_starred_by(post_id).unwrap_or(Vec::new()),
             config: config.clone(),
-            comments, user, title,
+            comments, user, title, legacy_comments,
             ..default()
         }))
     } else if conn.check_invite_token_exists(uuid) && user.id == 0 {
@@ -1044,10 +1049,9 @@ struct ModerateCommentForm {
     action: String,
 }
 
-#[get("/rebake-all-posts")]
-fn rebake_all_posts(conn: MoreInterestingConn, _user: Moderator) -> &'static str {
-    let max = conn.maximum_post_id();
-    for i in 0 ..= max {
+#[get("/rebake/:from/:to")]
+fn rebake(conn: MoreInterestingConn, _user: Moderator, from: i32, to: i32) -> &'static str {
+    for i in from ..= to {
         if let Ok(post) = conn.get_post_by_id(i) {
             let _ = conn.update_post(i, &NewPost{
                 title: &post.title[..],
@@ -1056,6 +1060,12 @@ fn rebake_all_posts(conn: MoreInterestingConn, _user: Moderator) -> &'static str
                 submitted_by: post.submitted_by,
                 visible: post.visible
             });
+        }
+        if let Ok(comment) = conn.get_comment_by_id(i) {
+            let _ = conn.update_comment(i, comment.id, &comment.text);
+        }
+        if let Ok(legacy_comment) = conn.get_legacy_comment_by_id(i) {
+            let _ = conn.update_legacy_comment(i, comment.id, &comment.text);
         }
     }
     "done"
@@ -1216,7 +1226,7 @@ fn main() {
             }
             Ok(rocket)
         }))
-        .mount("/", routes![index, login_form, login, logout, create_link_form, create_post_form, create, get_comments, vote, signup, get_settings, create_invite, invite_tree, change_password, post_comment, vote_comment, get_edit_tags, edit_tags, get_tags, edit_post, get_edit_post, edit_comment, get_edit_comment, set_dark_mode, set_big_mode, mod_log, get_user_info, get_mod_queue, moderate_post, moderate_comment, get_public_signup, rebake_all_posts, random, redirect_legacy_id, latest, rss])
+        .mount("/", routes![index, login_form, login, logout, create_link_form, create_post_form, create, get_comments, vote, signup, get_settings, create_invite, invite_tree, change_password, post_comment, vote_comment, get_edit_tags, edit_tags, get_tags, edit_post, get_edit_post, edit_comment, get_edit_comment, set_dark_mode, set_big_mode, mod_log, get_user_info, get_mod_queue, moderate_post, moderate_comment, get_public_signup, rebake, random, redirect_legacy_id, latest, rss])
         .mount("/assets", StaticFiles::from("assets"))
         .attach(Template::custom(|engines| {
             engines.handlebars.register_helper("count", Box::new(count_helper));

--- a/src/models.rs
+++ b/src/models.rs
@@ -864,7 +864,7 @@ impl MoreInterestingConn {
             .values(CreateComment{
                 text: new_post.text,
                 html: &html_and_stuff.string,
-              g  post_id: new_post.post_id,
+                post_id: new_post.post_id,
                 created_by: new_post.created_by,
                 visible: new_post.visible,
             })

--- a/src/models.rs
+++ b/src/models.rs
@@ -72,7 +72,9 @@ pub struct LegacyComment {
     pub post_id: i32,
     pub author: String,
     pub text: String,
-    pub html: String
+    pub html: String,
+    pub created_at: NaiveDateTime,
+    pub updated_at: NaiveDateTime,
 }
 
 impl Default for User {

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -69,6 +69,20 @@ table! {
 table! {
     use crate::sql_types::*;
 
+    legacy_comments (id) {
+        id -> Int4,
+        post_id -> Int4,
+        author -> Varchar,
+        text -> Varchar,
+        html -> Varchar,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
+    }
+}
+
+table! {
+    use crate::sql_types::*;
+
     moderation (id) {
         id -> Int4,
         payload -> Jsonb,
@@ -165,6 +179,7 @@ joinable!(comments -> users (created_by));
 joinable!(flags -> posts (post_id));
 joinable!(flags -> users (user_id));
 joinable!(invite_tokens -> users (invited_by));
+joinable!(legacy_comments -> posts (post_id));
 joinable!(moderation -> users (created_by));
 joinable!(post_search_index -> posts (post_id));
 joinable!(post_tagging -> posts (post_id));
@@ -181,6 +196,7 @@ allow_tables_to_appear_in_same_query!(
     domains,
     flags,
     invite_tokens,
+    legacy_comments,
     moderation,
     post_search_index,
     post_tagging,

--- a/templates/comments.hbs
+++ b/templates/comments.hbs
@@ -34,6 +34,16 @@
             </form>
             </footer>
         </article>
+        {{#each legacy_comments}}
+            <aside id="{{this.id}}"><details open><summary title="Hide comment" class=module-summary>Show comment</summary>
+                <main>{{{this.html}}}</main>
+                <footer>
+                    old comment posted by {{this.author}}
+                    {{date this.created_at}}
+                    <a href="#{{this.id}}">#{{this.id}}</a>
+                </footer>
+            </details></aside>
+        {{/each}}
         {{#each comments}}
             <aside id="{{this.id}}"><details open><summary title="Hide comment" class=module-summary>Show comment</summary>
                 <main>{{{this.html}}}</main>


### PR DESCRIPTION
These comments should be created elsewhere, not by MI itself,
and are really most useful when migrating from another chat app.