### PR TITLE
Fix stupid bug where it randomly ignores comments

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -982,6 +982,19 @@ fn get_mod_queue(conn: MoreInterestingConn, user: Moderator, flash: Option<Flash
             ..default()
         }))
     }
+    if let Some(comment_info) = conn.find_moderated_comment(user.0.id) {
+        let post_info = conn.get_post_info_from_comment(user.0.id, comment_info.id).unwrap();
+        return Ok(Template::render("mod-queue", &TemplateContext {
+            title: Cow::Borrowed("moderate comment"),
+            parent: "layout",
+            alert: flash.map(|f| f.msg().to_owned()),
+            config: config.clone(),
+            comments: vec![comment_info],
+            posts: vec![post_info],
+            user: user.0,
+            ..default()
+        }))
+    }
     Ok(Template::render("mod-queue", &TemplateContext {
         title: Cow::Borrowed("moderator queue is empty!"),
         parent: "layout",


### PR DESCRIPTION
We want to randomly choose between moderating a comment and a quote.
If there are comments present and not quotes, though, we still want to do the
comment no matter what the coin flip says.