### PR TITLE
Add a space between the domain and title

### DIFF
--- a/src/prettify.rs
+++ b/src/prettify.rs
@@ -274,7 +274,7 @@ pub fn prettify_title<D: Data>(mut text: &str, url: &str, data: &mut D) -> Outpu
             if host.starts_with("www.") {
                 host = &host[4..];
             }
-            ret_val.push_str("</span><span class=article-header-inner><a class=domain-link href=\"./?domain=");
+            ret_val.push_str("</span> <span class=article-header-inner><a class=domain-link href=\"./?domain=");
             ret_val.push_str(host);
             ret_val.push_str("\">");
             ret_val.push_str(host);


### PR DESCRIPTION
This fixes behavior in screenreaders, copy-paste, and text browsers.