### PR TITLE
Remove extra spaces from titles

### DIFF
--- a/src/prettify.rs
+++ b/src/prettify.rs
@@ -723,7 +723,7 @@ pub fn prettify_body_bbcode<D: Data>(text: &str, data: &mut D) -> Output {
 
 /// Prettify a title line: similar to `prettify_body`, but without paragraph breaks
 pub fn prettify_title<D: Data>(text: &str, url: &str, data: &mut D) -> Output {
-    let text = SPACES.replace(text, " ");
+    let text = SPACES.replace_all(text, " ");
     let mut text = &text[..];
     let mut ret_val = Output::with_capacity(text.len());
     let link = format!("</span><span class=article-header-inner><a href=\"{}\">", url);

--- a/src/prettify.rs
+++ b/src/prettify.rs
@@ -1223,7 +1223,7 @@ mod test {
     #[test]
     fn test_double_space_title() {
         let comment = "test   #words   #words";
-        let html = "<span class=article-header-inner><a href=\"url\">test </a></span><span class=article-header-inner><a class=inner-link href=\"./?tag=words\">#words </a></span><span class=article-header-inner><a class=inner-link href=\"./?tag=words\">#words</a></span>";
+        let html = "<span class=article-header-inner><a href=\"url\">test </a></span><span class=article-header-inner><a class=inner-link href=\"./?tag=words\">#words</a></span><span class=article-header-inner><a class=inner-link href=\"./?tag=words\">#words</a></span>";
         struct MyData;
         impl Data for MyData {
             fn check_comment_ref(&mut self, id: i32) -> bool {

--- a/src/prettify.rs
+++ b/src/prettify.rs
@@ -1223,7 +1223,7 @@ mod test {
     #[test]
     fn test_double_space_title() {
         let comment = "test   #words   #words";
-        let html = "<span class=article-header-inner><a href=\"url\">test </a></span><span class=article-header-inner><a class=inner-link href=\"./?tag=words\">#words</a></span><span class=article-header-inner><a class=inner-link href=\"./?tag=words\">#words</a></span>";
+        let html = "<span class=article-header-inner><a href=\"url\">test </a></span><span class=article-header-inner><a class=inner-link href=\"./?tag=words\">#words</a> </span><span class=article-header-inner><a class=inner-link href=\"./?tag=words\">#words</a></span>";
         struct MyData;
         impl Data for MyData {
             fn check_comment_ref(&mut self, id: i32) -> bool {


### PR DESCRIPTION
That one visitor does it constantly. It's simpler just to fix the app.